### PR TITLE
Unescape special characters in question name and text

### DIFF
--- a/pygiftparser/gift.py
+++ b/pygiftparser/gift.py
@@ -24,7 +24,21 @@ class QuestionFactory(object):
         p = re.compile(r'^::(.+)::(.+)$')
         m = p.match(raw_text)
         name = m.group(1).strip() if m and m.group(1) else raw_text
+        name = name\
+            .replace("\\:", ":")\
+            .replace("\\~", "~")\
+            .replace("\\=", "=")\
+            .replace("\\#", "#")\
+            .replace("\\{", "{")\
+            .replace("\\}", "}")
         text = m.group(2).strip() if m and m.group(2) else raw_text
+        text = text\
+            .replace("\\:", ":")\
+            .replace("\\~", "~")\
+            .replace("\\=", "=")\
+            .replace("\\#", "#")\
+            .replace("\\{", "{")\
+            .replace("\\}", "}")
         return Question(
             name=name, text=text, answer=answer, text_continue=text_continue, category=category
         )

--- a/tests/test_escaping.py
+++ b/tests/test_escaping.py
@@ -1,0 +1,42 @@
+import unittest
+
+from pygiftparser import parser
+from pygiftparser.gift import TrueFalse
+
+
+class TestEscapingQuestionTitle(unittest.TestCase):
+    def setUp(self):
+        self.result = parser.parse(
+            """
+            ::Characters in Title\: \~ \= \# \{ \}:: Question text {T}            
+            """
+        )
+        self.question = self.result.questions[0]
+        self.answer = self.question.answer
+        self.options = self.answer.options
+
+    def tearDown(self):
+        self.result.questions = []
+        self.result = None
+
+    def test_escaping_in_question_text_is_unescaped(self):
+        self.assertEqual(self.question.name, "Characters in Title: ~ = # { }")
+
+
+class TestEscapingQuestionText(unittest.TestCase):
+    def setUp(self):
+        self.result = parser.parse(
+            """
+            ::Title:: Special characters in question\: \~ \= \# \{ \} {T}            
+            """
+        )
+        self.question = self.result.questions[0]
+        self.answer = self.question.answer
+        self.options = self.answer.options
+
+    def tearDown(self):
+        self.result.questions = []
+        self.result = None
+
+    def test_escaping_in_question_text_is_unescaped(self):
+        self.assertEqual(self.question.text, "Special characters in question: ~ = # { }")

--- a/tests/test_multiple_choice_checkbox.py
+++ b/tests/test_multiple_choice_checkbox.py
@@ -147,7 +147,7 @@ class TestMultipleChoiceCheckboxQuestionWithName(TestMultipleChoiceCheckboxQuest
 
 
     def test_name_and_text_of_questions(self):
-        self.assertEqual(self.question.name, "With name\=4: yes")
+        self.assertEqual(self.question.name, "With name=4: yes")
         self.assertEqual(self.question.text, "What two people are entombed in Grant's tomb?")
         self.assertEqual(self.question.text_continue, None)
 


### PR DESCRIPTION
Some GIFT parser tools and libraries excpect escaping of special GIFT characters inside the question text and title. When parsing such question collections the special characters should be unescaped.

Tools expecting escaped special characters:
- [Ehan Ous VSCode plugin](https://github.com/ethan-ou/vscode-gift)
- [GIFT Question Editor](https://fuhrmanator.github.io/GIFT-grammar-PEG.js/editor/editor.html)